### PR TITLE
Fix order of arguments of calloc call

### DIFF
--- a/egl.c
+++ b/egl.c
@@ -74,7 +74,7 @@ EGLDeviceEXT GetEglDevice(void)
     }
 
     /* Allocate memory to store that many EGLDeviceEXTs. */
-    devices = calloc(sizeof(EGLDeviceEXT), numDevices);
+    devices = calloc(numDevices, sizeof(EGLDeviceEXT));
 
     if (devices == NULL) {
         Fatal("Memory allocation failure.\n");


### PR DESCRIPTION
According to the man page of [calloc](https://linux.die.net/man/3/calloc) it seems the number of elements comes first and the struct size second.